### PR TITLE
MAUI-856078-[Others]-KB Corrections.

### DIFF
--- a/MauiApp1/MainPage.xaml.cs
+++ b/MauiApp1/MainPage.xaml.cs
@@ -1,5 +1,6 @@
 ﻿
 using Syncfusion.Maui.DataGrid;
+using Syncfusion.Maui.Inputs;
 
 namespace MauiApp1
 {
@@ -30,7 +31,7 @@ namespace MauiApp1
                 if (this.DataGrid.SelectedRows.Any(row => row == dataColumn.RowData))
                 {
                     gridCell.TextColor = gridStyle?.SelectedRowTextColor;
-                    Label sfLabel = dataColumn.ColumnElement?.Content as Label;
+                    SfNumericEntry sfLabel = dataColumn.ColumnElement?.Content as SfNumericEntry;
                     if (sfLabel != null)
                     {
                         sfLabel.TextColor = gridStyle?.SelectedRowTextColor;
@@ -39,7 +40,7 @@ namespace MauiApp1
                 else
                 {
                     gridCell.TextColor = gridStyle?.RowTextColor;
-                    Label sfLabel = dataColumn.ColumnElement?.Content as Label;
+                    SfNumericEntry sfLabel = dataColumn.ColumnElement?.Content as SfNumericEntry;
                     if (sfLabel != null)
                     {
                         sfLabel.TextColor = gridStyle?.RowTextColor;

--- a/MauiApp1/MainPage.xaml.cs
+++ b/MauiApp1/MainPage.xaml.cs
@@ -1,6 +1,5 @@
 ﻿
 using Syncfusion.Maui.DataGrid;
-using Syncfusion.Maui.Inputs;
 
 namespace MauiApp1
 {
@@ -31,7 +30,7 @@ namespace MauiApp1
                 if (this.DataGrid.SelectedRows.Any(row => row == dataColumn.RowData))
                 {
                     gridCell.TextColor = gridStyle?.SelectedRowTextColor;
-                    SfNumericEntry sfLabel = dataColumn.ColumnElement?.Content as SfNumericEntry;
+                    SfDataGridLabel sfLabel = dataColumn.ColumnElement?.Content as SfDataGridLabel;
                     if (sfLabel != null)
                     {
                         sfLabel.TextColor = gridStyle?.SelectedRowTextColor;
@@ -40,7 +39,7 @@ namespace MauiApp1
                 else
                 {
                     gridCell.TextColor = gridStyle?.RowTextColor;
-                    SfNumericEntry sfLabel = dataColumn.ColumnElement?.Content as SfNumericEntry;
+                    SfDataGridLabel sfLabel = dataColumn.ColumnElement?.Content as SfDataGridLabel;
                     if (sfLabel != null)
                     {
                         sfLabel.TextColor = gridStyle?.RowTextColor;

--- a/MauiApp1/MauiApp1.csproj
+++ b/MauiApp1/MauiApp1.csproj
@@ -49,7 +49,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Syncfusion.Maui.DataGrid" Version="23.1.44" />
+	  <PackageReference Include="Syncfusion.Maui.DataGrid" Version="23.2.4" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Description
When We use customer renderer, we have to rename the control name as SfDataGridLable instead of Label based on renderer type.